### PR TITLE
fix: add rdb-channel awareness to replicationSetupSlaveForXFullResync

### DIFF
--- a/xredis/tests/gtid/8_x/replication-rdbchannel.tcl
+++ b/xredis/tests/gtid/8_x/replication-rdbchannel.tcl
@@ -1,0 +1,1085 @@
+#
+# Copyright (c) 2009-Present, Redis Ltd.
+# All rights reserved.
+#
+# Copyright (c) 2024-present, Valkey contributors.
+# All rights reserved.
+#
+# Licensed under your choice of (a) the Redis Source Available License 2.0
+# (RSALv2); or (b) the Server Side Public License v1 (SSPLv1); or (c) the
+# GNU Affero General Public License v3 (AGPLv3).
+#
+# Portions of this file are available under BSD3 terms; see REDISCONTRIBUTIONS for more information.
+#
+
+# Returns either main or rdbchannel client id
+# Assumes there is one replica with two channels
+proc get_replica_client_id {master rdbchannel} {
+    set input [$master client list type replica]
+
+    foreach line [split $input "\n"] {
+        if {[regexp {id=(\d+).*flags=(\S+)} $line match id flags]} {
+            if {$rdbchannel == "yes"} {
+                # rdbchannel will have C flag
+                if {[string match *C* $flags]} {
+                    return $id
+                }
+            } else {
+                return $id
+            }
+        }
+    }
+
+    error "Replica not found"
+}
+
+proc replication_rdbchannel_log_context {srv_idx from_line {max_lines 80}} {
+    set stdout [srv $srv_idx stdout]
+    set first_line [expr {$from_line + 1}]
+    set lines [split [exec tail -n +$first_line < $stdout] "\n"]
+    set outcome_lines {}
+
+    foreach line $lines {
+        if {[string match "*Background transfer error*" $line] ||
+            [string match "*Background transfer terminated by signal*" $line] ||
+            [string match "*Background RDB transfer terminated with success*" $line]} {
+            lappend outcome_lines $line
+        }
+    }
+
+    if {[llength $lines] > $max_lines} {
+        set lines [lrange $lines end-[expr {$max_lines - 1}] end]
+    }
+    set excerpt [join $lines "\n"]
+
+    if {[llength $outcome_lines] == 0} {
+        set outcome_lines "<none>"
+    } else {
+        set outcome_lines [join $outcome_lines "\n"]
+    }
+
+    return "master outcome log lines since line $from_line:\n$outcome_lines\nmaster log excerpt:\n$excerpt"
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set replica1 [srv 0 client]
+
+    start_server {overrides {gtid-enabled yes}} {
+        set replica2 [srv 0 client]
+
+        start_server {overrides {gtid-enabled yes}} {
+            set master [srv 0 client]
+            set master_host [srv 0 host]
+            set master_port [srv 0 port]
+
+            $master config set repl-diskless-sync yes
+            $master config set repl-rdb-channel yes
+            populate 1000 master 10
+            $master config set gtid-xsync-max-gap 1
+            $replica1 config set gtid-xsync-max-gap 0
+            $replica2 config set gtid-xsync-max-gap 0
+
+
+            test "Test replication with multiple replicas (rdbchannel enabled on both)" {
+                $replica1 config set repl-rdb-channel yes
+                $replica1 replicaof $master_host $master_port
+
+                $replica2 config set repl-rdb-channel yes
+                $replica2 replicaof $master_host $master_port
+
+                wait_replica_online $master 0
+                wait_replica_online $master 1
+
+                $master set x 1
+
+                # Wait until replicas catch master
+                wait_for_ofs_sync $master $replica1
+                wait_for_ofs_sync $master $replica2
+
+                # Verify db's are identical
+                assert_morethan [$master dbsize] 0
+                assert_equal [$master get x] 1
+                assert_equal [$master debug digest] [$replica1 debug digest]
+                assert_equal [$master debug digest] [$replica2 debug digest]
+            }
+
+            test "Test replication with multiple replicas (rdbchannel enabled on one of them)" {
+                # Allow both replicas to ask for sync
+                $master config set repl-diskless-sync-delay 5
+                # GTID: slave's preserved gtid_executed is a subset of master's, so by
+                # construction gap==0 in masterAnaXsyncRequest (mexec == sexec by math).
+                # Adding 2 local commands on each replica makes slave gtid_executed
+                # exceed master's; combined with maxgap=0 this guarantees fullsync.
+                $replica1 config set gtid-xsync-max-gap 0
+                $replica2 config set gtid-xsync-max-gap 0
+
+                $replica1 replicaof no one
+                $replica2 replicaof no one
+                $replica1 config set repl-rdb-channel yes
+                $replica2 config set repl-rdb-channel no
+                $replica1 set k1 1
+                $replica1 set k1 2
+                $replica2 set k2 1
+                $replica2 set k2 2
+
+                set loglines [count_log_lines 0]
+                set prev_forks [s 0 total_forks]
+                $master set x 2
+
+                # There will be two forks subsequently, one for rdbchannel
+                # replica another for the replica without rdbchannel config.
+                $replica1 replicaof $master_host $master_port
+                $replica2 replicaof $master_host $master_port
+
+                # There will be two forks subsequently, one for rdbchannel
+                # replica, another for the replica without rdbchannel config.
+                wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets (rdb-channel)*"} $loglines 300 100
+                wait_for_log_messages 0 {"*Starting BGSAVE* replicas sockets"} $loglines 300 100
+
+                wait_replica_online $master 0 100 100
+                wait_replica_online $master 1 100 100
+
+                # Verify two new forks.
+                assert_equal [s 0 total_forks] [expr $prev_forks + 2]
+
+                wait_for_ofs_sync $master $replica1
+                wait_for_ofs_sync $master $replica2
+
+                # Verify db's are identical
+                assert_equal [$replica1 get x] 2
+                assert_equal [$replica2 get x] 2
+                assert_equal [$master debug digest] [$replica1 debug digest]
+                assert_equal [$master debug digest] [$replica2 debug digest]
+            }
+
+            test "Test rdbchannel is not used if repl-diskless-sync config is disabled on master" {
+                $replica1 replicaof no one
+                $replica2 replicaof no one
+
+                $master config set repl-diskless-sync-delay 0
+                $master config set repl-diskless-sync no
+                # GTID: force fullsync (see test 2 comment).
+                $replica1 config set gtid-xsync-max-gap 0
+                $replica1 replicaof no one
+                $replica1 set k1 1
+                $replica1 set k1 2
+
+                $master set x 3
+                $replica1 replicaof $master_host $master_port
+
+                # Verify log message does not mention rdbchannel
+                wait_for_log_messages 0 {"*Starting BGSAVE for SYNC with target: disk*"} 0 2000 1
+
+                wait_replica_online $master 0
+                wait_for_ofs_sync $master $replica1
+
+                # Verify db's are identical
+                assert_equal [$replica1 get x] 3
+                assert_equal [$master debug digest] [$replica1 debug digest]
+            }
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set replica [srv 0 client]
+    set replica_pid [srv 0 pid]
+
+    start_server {overrides {gtid-enabled yes}} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        $master config set repl-rdb-channel yes
+        $replica config set repl-rdb-channel yes
+
+        # Reuse this test to verify large key delivery
+        $master config set rdbcompression no
+        $master config set rdb-key-save-delay 3000
+        populate 1000 prefix1 10
+        populate 5 prefix2 3000000
+        populate 5 prefix3 2000000
+        populate 5 prefix4 1000000
+
+        $master config set gtid-xsync-max-gap 0
+        $replica config set gtid-xsync-max-gap 0
+
+        # On master info output, we should see state transition in this order:
+        # 1. wait_bgsave: Replica receives psync error (+RDBCHANNELSYNC)
+        # 2. send_bulk_and_stream: Replica opens rdbchannel and delivery started
+        # 3. online: Sync is completed
+        test "Test replica state should start with wait_bgsave" {
+            $replica config set key-load-delay 100000
+            # Pause replica before opening rdb channel conn
+            $replica debug repl-pause before-rdb-channel
+            $replica replicaof $master_host $master_port
+
+            wait_for_condition 50 200 {
+                [s 0 connected_slaves] == 1 &&
+                [string match "*wait_bgsave*" [s 0 slave0]]
+            } else {
+                fail "replica failed"
+            }
+        }
+
+        test "Test replica state advances to send_bulk_and_stream when rdbchannel connects" {
+            $master set x 1
+            resume_process $replica_pid
+
+            wait_for_condition 50 200 {
+                [s 0 connected_slaves] == 1 &&
+                [s 0 rdb_bgsave_in_progress] == 1 &&
+                [string match "*send_bulk_and_stream*" [s 0 slave0]]
+            } else {
+                fail "replica failed"
+            }
+        }
+
+        test "Test replica rdbchannel client has SC flag on client list output" {
+            set input [$master client list type replica]
+
+            # There will two replicas, second one should be rdbchannel
+            set trimmed_input [string trimright $input]
+            set lines [split $trimmed_input "\n"]
+            if {[llength $lines] < 2} {
+                error "There is no second line in the input: $input"
+            }
+            set second_line [lindex $lines 1]
+
+            # Check if 'flags=SC' exists in the second line
+            if {![regexp {flags=SC} $second_line]} {
+                error "Flags are not 'SC' in the second line: $second_line"
+            }
+        }
+
+        test "Test replica state advances to online when fullsync is completed" {
+            # Speed up loading
+            $replica config set key-load-delay 0
+
+            wait_replica_online $master 0 100 1000
+            wait_for_ofs_sync $master $replica
+
+            wait_for_condition 50 200 {
+                [s 0 rdb_bgsave_in_progress] == 0 &&
+                [s 0 connected_slaves] == 1 &&
+                [string match "*online*" [s 0 slave0]]
+            } else {
+                fail "replica failed"
+            }
+
+            wait_replica_online $master 0 100 1000
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set replica [srv 0 client]
+
+    start_server {overrides {gtid-enabled yes}} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        $master config set repl-rdb-channel yes
+        $replica config set repl-rdb-channel yes
+        $master config set gtid-xsync-max-gap 0
+        $replica config set gtid-xsync-max-gap 0
+
+        test "Test master memory does not increase during replication" {
+            # Put some delay to rdb generation. If master doesn't forward
+            # incoming traffic to replica, master's replication buffer will grow
+            $master config set repl-diskless-sync-delay 0
+            $master config set rdb-key-save-delay 500 ;# 500us delay and 10k keys means at least 5 seconds replication
+            $master config set repl-backlog-size 5mb
+            $replica config set replica-full-sync-buffer-limit 200mb
+            populate 10000 master 10000 ;# 10k keys of 10k, means 100mb
+            $replica config set loading-process-events-interval-bytes 262144 ;# process events every 256kb of rdb or command stream
+
+            # Start write traffic
+            set load_handle [start_write_load $master_host $master_port 100 "key1" 5000 4]
+
+            set prev_used [s 0 used_memory]
+
+            $replica replicaof $master_host $master_port
+            set backlog_size [lindex [$master config get repl-backlog-size] 1]
+
+            # Verify used_memory stays low
+            set max_retry 1000
+            set peak_replica_buf_size 0
+            set peak_master_slave_buf_size 0
+            set peak_master_used_mem 0
+            set peak_master_rpl_buf 0
+            while {$max_retry} {
+                set replica_buf_size [s -1 replica_full_sync_buffer_size]
+                set master_slave_buf_size [s mem_clients_slaves]
+                set master_used_mem [s used_memory]
+                set master_rpl_buf [s mem_total_replication_buffers]
+                if {$replica_buf_size > $peak_replica_buf_size} {set peak_replica_buf_size $replica_buf_size}
+                if {$master_slave_buf_size > $peak_master_slave_buf_size} {set peak_master_slave_buf_size $master_slave_buf_size}
+                if {$master_used_mem > $peak_master_used_mem} {set peak_master_used_mem $master_used_mem}
+                if {$master_rpl_buf > $peak_master_rpl_buf} {set peak_master_rpl_buf $master_rpl_buf}
+                if {$::verbose} {
+                    puts "[clock format [clock seconds] -format %H:%M:%S] master: $master_slave_buf_size replica: $replica_buf_size"
+                }
+
+                # Wait for the replica to finish reading the rdb (also from the master's perspective), and also consume much of the replica buffer
+                if {[string match *slave0*state=online* [$master info]] &&
+                    [s -1 master_link_status] == "up" &&
+                    $replica_buf_size < 1000000} {
+                    break
+                } else {
+                    incr max_retry -1
+                    after 10
+                }
+            }
+            if {$max_retry == 0} {
+                error "assertion:Replica not in sync after 10 seconds"
+            }
+
+            if {$::verbose} {
+                puts "peak_master_used_mem $peak_master_used_mem"
+                puts "peak_master_rpl_buf $peak_master_rpl_buf"
+                puts "peak_master_slave_buf_size $peak_master_slave_buf_size"
+                puts "peak_replica_buf_size $peak_replica_buf_size"
+            }
+            # memory on the master is less than 1mb
+            assert_lessthan [expr $peak_master_used_mem - $prev_used - $backlog_size] 1000000
+            assert_lessthan $peak_master_rpl_buf [expr {$backlog_size + 1000000}]
+            assert_lessthan $peak_master_slave_buf_size 1000000
+            # buffers in the replica are more than 5mb
+            assert_morethan $peak_replica_buf_size 5000000
+
+            stop_write_load $load_handle
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set replica [srv 0 client]
+
+    start_server {overrides {gtid-enabled yes}} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        $master config set repl-rdb-channel yes
+        $replica config set repl-rdb-channel yes
+        $master config set  gtid-xsync-max-gap 0
+        $replica config set gtid-xsync-max-gap 0
+
+        test "Test replication stream buffer becomes full on replica" {
+            # For replication stream accumulation, replica inherits slave output
+            # buffer limit as the size limit. In this test, we create traffic to
+            # fill the buffer fully. Once the limit is reached, accumulation
+            # will stop. This is not a failure scenario though. From that point,
+            # further accumulation may occur on master side. Replication should
+            # be completed successfully.
+
+            # Create some artificial delay for rdb delivery and load. We'll
+            # generate some traffic to fill the replication buffer.
+            $master config set rdb-key-save-delay 1000
+            $replica config set key-load-delay 1000
+            $replica config set client-output-buffer-limit "replica 64kb 64kb 0"
+            populate 2000 master 1
+
+            set prev_sync_full [s 0 sync_full]
+            $replica replicaof $master_host $master_port
+
+            # Wait for replica to establish psync using main channel
+            wait_for_condition 500 1000 {
+                [string match "*state=send_bulk_and_stream*" [s 0 slave0]]
+            } else {
+                fail "replica didn't start sync"
+            }
+
+            # Create some traffic on replication stream
+            populate 100 master 100000
+
+            # Wait for replica's buffer limit reached
+            wait_for_log_messages -1 {"*Replication buffer limit has been reached*"} 0 1000 10
+
+            # Speed up loading
+            $replica config set key-load-delay 0
+
+            # Wait until sync is successful
+            wait_for_condition 200 200 {
+                [status $master master_repl_offset] eq [status $replica master_repl_offset] &&
+                [status $master master_repl_offset] eq [status $replica slave_repl_offset]
+            } else {
+                fail "replica offsets didn't match in time"
+            }
+
+            # Verify sync was not interrupted.
+            assert_equal [s 0 sync_full] [expr $prev_sync_full + 1]
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+
+        test "Test replication stream buffer config replica-full-sync-buffer-limit" {
+            # By default, replica inherits client-output-buffer-limit of replica
+            # to limit accumulated repl data during rdbchannel sync.
+            # replica-full-sync-buffer-limit should override it if it is set.
+            $replica replicaof no one
+            # GTID: force fullsync. Slave's preserved gtid matches master's, so
+            # partial sync would be accepted. Add local commands + maxgap=0 so
+            # master's gap>0 rejection forces a full rdb channel sync.
+            $replica config set gtid-xsync-max-gap 0
+            $replica set d1 1
+            $replica set d1 2
+
+            # Create some artificial delay for rdb delivery and load. We'll
+            # generate some traffic to fill the replication buffer.
+            $master config set rdb-key-save-delay 1000
+            $replica config set key-load-delay 1000
+            $replica config set client-output-buffer-limit "replica 1024 1024 0"
+            $replica config set replica-full-sync-buffer-limit 20mb
+            populate 2000 master 1
+
+            $replica replicaof $master_host $master_port
+
+            # Wait until replication starts
+            wait_for_condition 500 1000 {
+                [string match "*state=send_bulk_and_stream*" [s 0 slave0]]
+            } else {
+                fail "replica didn't start sync"
+            }
+
+            # Create some traffic on replication stream
+            populate 100 master 100000
+
+            # Make sure config is used, we accumulated more than
+            # client-output-buffer-limit
+            assert_morethan [s -1 replica_full_sync_buffer_size] 1024
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+    set master_pid  [srv 0 pid]
+    set loglines [count_log_lines 0]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set repl-backlog-size 1mb
+    $master config set client-output-buffer-limit "replica 100k 0 0"
+    $master config set repl-diskless-sync-delay 3
+    
+
+
+
+    start_server {overrides {gtid-enabled yes}} {
+        set replica [srv 0 client]
+        set replica_pid [srv 0 pid]
+
+        $replica config set repl-rdb-channel yes
+        $replica config set repl-timeout 10
+        $replica config set key-load-delay 10000
+        $replica config set loading-process-events-interval-bytes 1024
+        $master config set gtid-xsync-max-gap 0
+        $replica config set gtid-xsync-max-gap 0
+
+        test "Test master disconnects replica when output buffer limit is reached" {
+            populate 20000 master 100 -1
+
+            $replica replicaof $master_host $master_port
+            wait_for_condition 100 200 {
+                [s 0 loading] == 1
+            } else {
+                fail "Replica did not start loading"
+            }
+
+            # Generate replication traffic of ~20mb to disconnect the slave on obuf limit
+            populate 20 master 1000000 -1
+
+            wait_for_log_messages -1 {"*Client * closed * for overcoming of output buffer limits.*"} $loglines 1000 10
+            $replica config set key-load-delay 0
+
+            # Wait until replica loads RDB
+            wait_for_log_messages 0 {"*Done loading RDB*"} 0 1000 10
+        }
+
+        test "Test replication recovers after output buffer failures" {
+            # Verify system is operational
+            $master set x 1
+
+            # Wait until replica catches up
+            wait_replica_online $master 0 1000 100
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$replica get x] 1
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set rdb-key-save-delay 300
+    $master config set client-output-buffer-limit "replica 0 0 0"
+    $master config set repl-diskless-sync-delay 5
+
+    populate 10000 master 1
+
+    start_server {overrides {gtid-enabled yes}} {
+        set replica1 [srv 0 client]
+        $replica1 config set repl-rdb-channel yes
+
+        start_server {overrides {gtid-enabled yes}} {
+            set replica2 [srv 0 client]
+            $replica2 config set repl-rdb-channel yes
+
+            $master config set gtid-xsync-max-gap 0
+            $replica1 config set gtid-xsync-max-gap 0
+            $replica2 config set gtid-xsync-max-gap 0
+
+            set load_handle [start_write_load $master_host $master_port 100 "key"]
+
+            test "Test master continues RDB delivery if not all replicas are dropped" {
+                $replica1 replicaof $master_host $master_port
+                $replica2 replicaof $master_host $master_port
+
+                wait_for_condition 50 200 {
+                    [s -2 rdb_bgsave_in_progress] == 1
+                } else {
+                    fail "Sync did not start"
+                }
+
+                # Verify replicas are connected
+                wait_for_condition 500 100 {
+                    [s -2 connected_slaves] == 2
+                } else {
+                    fail "Replicas didn't connect: [s -2 connected_slaves]"
+                }
+
+                # kill one of the replicas
+                catch {$replica1 shutdown nosave}
+
+                # Wait until replica completes full sync
+                # Verify there is no other full sync attempt
+                wait_for_condition 50 1000 {
+                    [s 0 master_link_status] == "up" &&
+                    [s -2 sync_full] == 2 &&
+                    [s -2 connected_slaves] == 1
+                } else {
+                    fail "Sync session did not continue
+                          master_link_status: [s 0 master_link_status]
+                          sync_full:[s -2 sync_full]
+                          connected_slaves: [s -2 connected_slaves]"
+                }
+
+                # Wait until replica catches up
+                wait_replica_online $master 0 200 100
+                wait_for_condition 200 100 {
+                    [s 0 mem_replica_full_sync_buffer] == 0
+                } else {
+                    fail "Replica did not consume buffer in time"
+                }
+            }
+
+            test "Test master ends rdb sync when all replicas are dropped" {
+                $replica2 replicaof no one
+                # GTID: force fullsync (slave's preserved gtid matches master's).
+                $replica2 config set gtid-xsync-max-gap 0
+                $replica2 set d1 1
+                $replica2 set d1 2
+
+                # Start replication
+                $replica2 replicaof $master_host $master_port
+
+                wait_for_condition 50 1000 {
+                    [s -2 rdb_bgsave_in_progress] == 1
+                } else {
+                    fail "Sync did not start"
+                }
+                set loglines [count_log_lines -2]
+
+                # kill replica
+                catch {$replica2 shutdown nosave}
+
+                # Verify master aborts rdb save
+                wait_for_condition 50 1000 {
+                    [s -2 rdb_bgsave_in_progress] == 0 &&
+                    [s -2 connected_slaves] == 0
+                } else {
+                    fail "Master should abort the sync
+                          rdb_bgsave_in_progress:[s -2 rdb_bgsave_in_progress]
+                          connected_slaves: [s -2 connected_slaves]
+                          [replication_rdbchannel_log_context -2 $loglines]"
+                }
+                # The strict "Background transfer error" outcome is covered by
+                # the dedicated rioConnsetWrite regression case below.
+            }
+
+            stop_write_load $load_handle
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set rdb-key-save-delay 1000
+
+    populate 3000 prefix1 1
+    populate 100 prefix2 100000
+
+    start_server {overrides {gtid-enabled yes}} {
+        set replica [srv 0 client]
+        set replica_pid [srv 0 pid]
+
+        $replica config set repl-rdb-channel yes
+        $replica config set repl-timeout 10
+
+        $master config set gtid-xsync-max-gap 0
+        $replica config set gtid-xsync-max-gap 0
+
+        set load_handle [start_write_load $master_host $master_port 100 "key"]
+
+        test "Test replica recovers when rdb channel connection is killed" {
+            $replica replicaof $master_host $master_port
+
+            # Wait for sync session to start
+            wait_for_condition 500 200 {
+                [string match "*state=send_bulk_and_stream*" [s -1 slave0]] &&
+                [s -1 rdb_bgsave_in_progress] eq 1
+            } else {
+                fail "replica didn't start sync session in time"
+            }
+
+            set loglines [count_log_lines -1]
+
+            # Kill rdb channel client
+            set id [get_replica_client_id $master yes]
+            $master client kill id $id
+
+            wait_for_log_messages -1 {"*Background transfer error*"} $loglines 1000 10
+
+            # Verify master rejects main-ch-client-id after connection is killed
+            assert_error {*Unrecognized*} {$master replconf main-ch-client-id $id}
+
+            # Replica should retry
+            wait_for_condition 500 200 {
+                [string match "*state=send_bulk_and_stream*" [s -1 slave0]] &&
+                [s -1 rdb_bgsave_in_progress] eq 1
+            } else {
+                fail "replica didn't retry after connection close"
+            }
+        }
+
+        test "Test replica recovers when main channel connection is killed" {
+            set loglines [count_log_lines -1]
+
+            # Kill main channel client
+            set id [get_replica_client_id $master yes]
+            $master client kill id $id
+
+            wait_for_log_messages -1 {"*Background transfer error*"} $loglines 1000 20
+
+            # Replica should retry
+            wait_for_condition 500 2000 {
+                [string match "*state=send_bulk_and_stream*" [s -1 slave0]] &&
+                [s -1 rdb_bgsave_in_progress] eq 1
+            } else {
+                fail "replica didn't retry after connection close"
+            }
+        }
+
+        stop_write_load $load_handle
+
+        test "Test replica recovers connection failures" {
+            # Wait until replica catches up
+            wait_replica_online $master 0 1000 100
+            wait_for_ofs_sync $master $replica
+
+            # Verify db's are identical
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip tsan:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set replica [srv 0 client]
+    set replica_pid  [srv 0 pid]
+
+    start_server {overrides {gtid-enabled yes}} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        $master config set gtid-xsync-max-gap 0
+        $replica config set gtid-xsync-max-gap 0
+
+        test "Test master connection drops while streaming repl buffer into the db" {
+            # Just after replica loads RDB, it will stream repl buffer into the
+            # db. During streaming, we kill the master connection. Replica
+            # will abort streaming and then try another psync with master.
+            $master config set rdb-key-save-delay 1000
+            $master config set repl-rdb-channel yes
+            $master config set repl-diskless-sync yes
+            $replica config set repl-rdb-channel yes
+            $replica config set loading-process-events-interval-bytes 1024
+
+            # Populate db and start write traffic
+            populate 2000 master 1000
+            set load_handle [start_write_load $master_host $master_port 100 "key1"]
+
+            # Replica will pause in the loop of repl buffer streaming
+            $replica debug repl-pause on-streaming-repl-buf
+            $replica replicaof $master_host $master_port
+
+            # Check if repl stream accumulation is started.
+            wait_for_condition 50 1000 {
+                [s -1 replica_full_sync_buffer_size] > 0
+            } else {
+                fail "repl stream accumulation not started"
+            }
+
+            # Wait until replica starts streaming repl buffer
+            wait_for_log_messages -1 {"*Starting to stream replication buffer*"} 0 2000 10
+            stop_write_load $load_handle
+            $master config set rdb-key-save-delay 0
+
+            # Kill master connection and resume the process
+            $replica deferred 1
+            $replica client kill type master
+            $replica debug repl-pause clear
+            resume_process $replica_pid
+            $replica read
+            $replica read
+            $replica deferred 0
+
+            wait_for_log_messages -1 {"*Master client was freed while streaming*"} 0 500 10
+
+            # Quick check for stats test coverage
+            assert_morethan_equal [s -1 replica_full_sync_buffer_peak] [s -1 replica_full_sync_buffer_size]
+
+            # Wait until replica recovers and verify db's are identical
+            wait_replica_online $master 0 1000 10
+            wait_for_ofs_sync $master $replica
+
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set replica [srv 0 client]
+    set replica_pid  [srv 0 pid]
+
+    start_server {overrides {gtid-enabled yes}} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        test "Test main channel connection drops while loading rdb (disk based)" {
+            # While loading rdb, we kill main channel connection.
+            # We expect replica to complete loading RDB and then try psync
+            # with the master.
+            $master config set repl-rdb-channel yes
+            $replica config set repl-rdb-channel yes
+            $replica config set repl-diskless-load disabled
+            $replica config set key-load-delay 10000
+            $replica config set loading-process-events-interval-bytes 1024
+
+            $master config set gtid-xsync-max-gap 0
+            $replica config set gtid-xsync-max-gap 0
+
+            # Populate db and start write traffic
+            populate 10000 master 100
+            $replica replicaof $master_host $master_port
+
+            # Wait until replica starts loading
+            wait_for_condition 50 200 {
+                [s -1 loading] == 1
+            } else {
+                fail "replica did not start loading"
+            }
+
+            # Kill replica connections
+            $master client kill type replica
+            $master set x 1
+
+            # At this point, we expect replica to complete loading RDB. Then,
+            # it will try psync with master.
+            wait_for_log_messages -1 {"*Aborting rdb channel sync while loading the RDB*"} 0 2000 10
+            wait_for_log_messages -1 {"*After loading RDB, replica will try psync with master*"} 0 2000 10
+
+            # Speed up loading
+            $replica config set key-load-delay 0
+
+            # Wait until replica becomes online
+            wait_replica_online $master 0 100 100
+
+            # Verify there is another successful psync and no other full sync
+            wait_for_condition 50 200 {
+                [s 0 sync_full] == 1 &&
+                [s 0 sync_partial_ok] == 1
+            } else {
+                fail "psync was not successful [s 0 sync_full] [s 0 sync_partial_ok]"
+            }
+
+            # Verify db's are identical after recovery
+            wait_for_ofs_sync $master $replica
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set replica [srv 0 client]
+    set replica_pid  [srv 0 pid]
+
+    start_server {overrides {gtid-enabled yes}} {
+        set master [srv 0 client]
+        set master_host [srv 0 host]
+        set master_port [srv 0 port]
+
+        test "Test main channel connection drops while loading rdb (diskless)" {
+            # While loading rdb, kill both main and rdbchannel connections.
+            # We expect replica to abort sync and later retry again.
+            $master config set repl-rdb-channel yes
+            $replica config set repl-rdb-channel yes
+            $replica config set repl-diskless-load swapdb
+            $replica config set key-load-delay 10000
+            $replica config set loading-process-events-interval-bytes 1024
+
+            $master config set gtid-xsync-max-gap 0
+            $replica config set gtid-xsync-max-gap 0
+
+            # Populate db and start write traffic
+            populate 10000 master 100
+
+            $replica replicaof $master_host $master_port
+
+            # Wait until replica starts loading
+            wait_for_condition 50 200 {
+                [s -1 loading] == 1
+            } else {
+                fail "replica did not start loading"
+            }
+
+            # Kill replica connections
+            $master client kill type replica
+            $master set x 1
+
+            # At this point, we expect replica to abort loading RDB.
+            wait_for_log_messages -1 {"*Aborting rdb channel sync while loading the RDB*"} 0 2000 10
+            wait_for_log_messages -1 {"*Failed trying to load the MASTER synchronization DB from socket*"} 0 2000 10
+
+            # Speed up loading
+            $replica config set key-load-delay 0
+
+            # Wait until replica recovers and becomes online
+            wait_replica_online $master 0 100 100
+
+            # Verify replica attempts another full sync
+            wait_for_condition 50 200 {
+                [s 0 sync_full] == 2 &&
+                [s 0 sync_partial_ok] == 0
+            } else {
+                fail "sync was not successful [s 0 sync_full] [s 0 sync_partial_ok]"
+            }
+
+            # Verify db's are identical after recovery
+            wait_for_ofs_sync $master $replica
+            assert_morethan [$master dbsize] 0
+            assert_equal [$master debug digest] [$replica debug digest]
+        }
+    }
+}
+
+start_server {tags {"repl external:skip tsan:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set master2 [srv 0 client]
+    set master2_host [srv 0 host]
+    set master2_port [srv 0 port]
+    start_server {tags {"repl external:skip"} overrides {gtid-enabled yes}} {
+        set replica [srv 0 client]
+        set replica_pid  [srv 0 pid]
+
+        start_server {overrides {gtid-enabled yes}} {
+            set master [srv 0 client]
+            set master_host [srv 0 host]
+            set master_port [srv 0 port]
+
+            test "Test replicaof command while streaming repl buffer into the db" {
+                # After replica loads the RDB, it will stream repl buffer into
+                # the db. During streaming, replica receives command
+                # "replicaof newmaster". Replica will abort streaming and then
+                # should be able to connect to the new master.
+                $master config set rdb-key-save-delay 1000
+                $master config set repl-rdb-channel yes
+                $master config set repl-diskless-sync yes
+                $replica config set repl-rdb-channel yes
+                $replica config set loading-process-events-interval-bytes 1024
+
+                $master config set gtid-xsync-max-gap 0
+                $replica config set gtid-xsync-max-gap 0
+
+                # Populate db and start write traffic
+                populate 2000 master 1000
+                set load_handle [start_write_load $master_host $master_port 100 "key1"]
+
+                # Replica will pause in the loop of repl buffer streaming
+                $replica debug repl-pause on-streaming-repl-buf
+                $replica replicaof $master_host $master_port
+
+                # Check if repl stream accumulation is started.
+                wait_for_condition 50 1000 {
+                    [s -1 replica_full_sync_buffer_size] > 0
+                } else {
+                    fail "repl stream accumulation not started"
+                }
+
+                # Wait until replica starts streaming repl buffer
+                wait_for_log_messages -1 {"*Starting to stream replication buffer*"} 0 2000 10
+                stop_write_load $load_handle
+                $master config set rdb-key-save-delay 0
+
+                # Populate the other master
+                populate 100 master2 100 -2
+
+                # Send "replicaof newmaster" command and resume the process
+                $replica deferred 1
+                $replica replicaof $master2_host $master2_port
+                $replica debug repl-pause clear
+                resume_process $replica_pid
+                $replica read
+                $replica read
+                $replica deferred 0
+
+                wait_for_log_messages -1 {"*Master client was freed while streaming*"} 0 500 10
+
+                # Wait until replica recovers and verify db's are identical
+                wait_replica_online $master2 0 1000 10
+                wait_for_ofs_sync $master2 $replica
+                assert_morethan [$master2 dbsize] 0
+                assert_equal [$master2 debug digest] [$replica debug digest]
+
+                # Try replication once more to be sure everything is okay.
+                $replica replicaof no one
+                $master2 set x 100
+
+                $replica replicaof $master2_host $master2_port
+                wait_replica_online $master2 0 1000 10
+                wait_for_ofs_sync $master2 $replica
+                assert_morethan [$master2 dbsize] 0
+                assert_equal [$master2 debug digest] [$replica debug digest]
+            }
+        }
+    }
+}
+
+# Regression test for rioConnsetWrite false-success bug:
+# When all replica connections fail on the LAST write (i.e. the write that
+# drains buflen to exactly 0), the in-loop "if (failed == n_dst) return 0"
+# check is never triggered because the failed counter is only incremented for
+# PRE-EXISTING failures, not for a connection that newly fails in the same
+# iteration.  The while loop exits normally (buflen==0), sdsclear() clears the
+# buffer, and the function returns 1 (success) even though every connection is
+# dead.  The subsequent rioConnsetFlush call finds an empty buffer, skips the
+# while loop entirely, and also returns 1.  The bgsave child then exits with
+# code 0 and the master logs "Background RDB transfer terminated with success"
+# instead of "Background transfer error".
+#
+# To make this deterministic the dataset is intentionally kept small enough
+# (< PROTO_IOBUF_LEN = 16 KB) so that no auto-flush ever fires during
+# serialisation and the ONLY socket write happens at rioConnsetFlush time
+# (after the last key has been serialised).  At that point the replica socket
+# is already dead, which reliably triggers the last-write failure path.
+start_server {tags {"repl external:skip" "memonly"} overrides {gtid-enabled yes}} {
+    set master [srv 0 client]
+    set master_host [srv 0 host]
+    set master_port [srv 0 port]
+
+    $master config set repl-diskless-sync yes
+    $master config set repl-rdb-channel yes
+    $master config set client-output-buffer-limit "replica 0 0 0"
+    # No sync delay: bgsave starts as soon as the replica connects.
+    $master config set repl-diskless-sync-delay 0
+    # 3 ms per key keeps bgsave running long enough to kill the replica
+    # well before the final rioConnsetFlush fires.
+    $master config set rdb-key-save-delay 3000
+
+    # ~500 keys * ~20 bytes/key in RDB ≈ 10 KB  <  PROTO_IOBUF_LEN (16 KB).
+    # All serialised data therefore stays in the user-space SDS buffer until
+    # the single final rioConnsetFlush call, making the trigger deterministic.
+    populate 500 riotest 1
+
+    start_server {overrides {gtid-enabled yes}} {
+        set replica [srv 0 client]
+        $replica config set repl-rdb-channel yes
+        $master config set gtid-xsync-max-gap 0
+        $replica config set gtid-xsync-max-gap 0
+
+        test "rioConnsetWrite: bgsave reports error when sole replica disconnects on last flush" {
+            set loglines [count_log_lines -1]
+            $replica replicaof $master_host $master_port
+
+            # Wait until bgsave has started; at this point the replica socket
+            # is held open by the bgsave child and NO data has been flushed yet
+            # (buffer < 16 KB).
+            wait_for_condition 50 100 {
+                [s -1 rdb_bgsave_in_progress] == 1
+            } else {
+                fail "bgsave did not start in time"
+            }
+
+            # Kill the replica while bgsave is still serialising keys.
+            catch {$replica shutdown nosave}
+            wait_for_condition 50 100 {
+                [s -1 connected_slaves] == 0
+            } else {
+                fail "replica did not disconnect after shutdown nosave \
+                      (connected_slaves: [s -1 connected_slaves])"
+            }
+
+            # The bgsave child has its own forked copy of rdb-key-save-delay
+            # and is not affected by parent config changes, so we do not
+            # attempt to speed it up here.
+
+            # The bgsave child will attempt a single rioConnsetFlush once all
+            # keys are serialised.  Because the socket is dead it must detect
+            # the failure and exit with code 1, causing the master to log
+            # "Background transfer error".
+            #
+            # Without the post-loop failed-connection check in rioConnsetWrite
+            # the function returns 1 (false success), the child exits with
+            # code 0, and the master logs "Background RDB transfer terminated
+            # with success" instead.  In that case wait_for_log_messages will
+            # time out and the test fails, pinpointing the bug.
+            wait_for_log_messages -1 {"*Background transfer error*"} $loglines 300 100
+
+            # Belt-and-suspenders: confirm the false-success path was NOT taken.
+            set stdout [srv -1 stdout]
+            set new_lines [exec tail -n +[expr $loglines + 1] < $stdout]
+            if {[string match "*Background RDB transfer terminated with success*" $new_lines]} {
+                fail "rioConnsetWrite false-success bug: master logged\
+                      'terminated with success' despite replica being dead"
+            }
+        }
+    }
+}

--- a/xredis/xredis_gtid_adaptation_version.h
+++ b/xredis/xredis_gtid_adaptation_version.h
@@ -34,10 +34,14 @@ void consumeReplicationBacklogLimitedAddReplyCb(char *p,
 void gtidClearReplStartCmdStreamOnAck(client* c);
 void gtidFreeClientAsync(client *c);
 int gtidMasterTryPartialResynchronization(client* c, long long psync_offset) ;
-
 void feedAppendOnlyFileGtid(struct redisCommand *_cmd, int dictid, robj **argv, int argc);
 void ctrip_replicationFeedSlaves(list* saves,int dictid, robj **argv,
         int argc, const char *uuid, size_t uuid_len, gno_t gno, long long offset);
+typedef sds build_xfull_protocol_cb();
+int replicationSetupSlaveForXFullResync(client *slave, long long offset, 
+        build_xfull_protocol_cb cb);
+/* Record the rdb-channel main client id negotiated via +RDBCHANNELSYNC (8.x impl; no-op in 6.x) */
+void gtidReplicationSetRdbChannelMainClientId(uint64_t client_id);
 
 /* backlog */
 long long gtidBacklogAppendToSds(long long offset, sds *dst, size_t size);

--- a/xredis/xredis_gtid_adaptation_version_6x.c
+++ b/xredis/xredis_gtid_adaptation_version_6x.c
@@ -326,6 +326,38 @@ struct redisCommand* gtidGetExecCommand() {
     return server.execCommand;
 }     
 
+/**
+    copy code from 6.x replicationSetupSlaveForFullResync   
+**/
+int replicationSetupSlaveForXFullResync(client *slave, long long offset,build_xfull_protocol_cb buildXfullProtocol) {
+    int buflen;
+
+    slave->psync_initial_offset = offset;
+    slave->replstate = SLAVE_STATE_WAIT_BGSAVE_END;
+    /* We are going to accumulate the incremental changes for this
+     * slave as well. Set slaveseldb to -1 in order to force to re-emit
+     * a SELECT statement in the replication stream. */
+    server.slaveseldb = -1;
+
+    /* Don't send this reply to slaves that approached us with
+     * the old SYNC command. */
+    if (!(slave->flags & CLIENT_PRE_PSYNC)) {
+        sds protocol = buildXfullProtocol(); //get protocol
+        buflen = sdslen(protocol);
+        if (connWrite(slave->conn,protocol, buflen) != buflen) { //send protocol
+            sdsfree(protocol); //free protocol
+            freeClientAsync(slave);
+            return C_ERR;
+        }
+        sdsfree(protocol); //free protocol
+    }
+    return C_OK;
+}
+
+/* 6.2.x has no rdb-channel replication; no-op to keep the shared code compilable. */
+void gtidReplicationSetRdbChannelMainClientId(uint64_t client_id) {
+    UNUSED(client_id);
+}
 
 
 /* test */

--- a/xredis/xredis_gtid_adaptation_version_8x.c
+++ b/xredis/xredis_gtid_adaptation_version_8x.c
@@ -346,6 +346,55 @@ long long gtidBacklogAppendToSds(long long offset, sds *dst, size_t size) {
     return total;
 }
 
+/**
+    copy code from 8.x replicationSetupSlaveForFullResync   
+**/
+int replicationSetupSlaveForXFullResync(client *slave, long long offset, build_xfull_protocol_cb buildXfullProtocol) {
+    int buflen;
+
+    slave->psync_initial_offset = offset;
+    slave->replstate = SLAVE_STATE_WAIT_BGSAVE_END;
+    /* We are going to accumulate the incremental changes for this
+     * slave as well. Set slaveseldb to -1 in order to force to re-emit
+     * a SELECT statement in the replication stream. */
+    server.slaveseldb = -1;
+
+    /* Don't send this reply to slaves that approached us with
+     * the old SYNC command. */
+    if (!(slave->flags & CLIENT_PRE_PSYNC)) {
+        if (slave->flags & CLIENT_REPL_RDB_CHANNEL) {
+            /* This slave is rdbchannel. Find its associated main channel and
+             * change its state so we can deliver replication stream from now
+             * on, in parallel to rdb. */
+            uint64_t id = slave->main_ch_client_id;
+            client *c = lookupClientByID(id);
+            if (c && c->replstate == SLAVE_STATE_WAIT_RDB_CHANNEL) {
+                c->replstate = SLAVE_STATE_SEND_BULK_AND_STREAM;
+                serverLog(LL_NOTICE, "Starting to deliver RDB and replication stream to replica: %s",
+                          replicationGetSlaveName(c));
+            } else {
+                serverLog(LL_WARNING, "Starting to deliver RDB to replica %s"
+                                      " but it has no associated main channel",
+                                      replicationGetSlaveName(slave));
+            }
+        }
+        sds protocol = buildXfullProtocol(); //get protocol
+        buflen = sdslen(protocol);
+        if (connWrite(slave->conn,protocol,buflen) != buflen) {  //send protocol
+            sdsfree(protocol); //free protocol
+            freeClientAsync(slave);
+            return C_ERR;
+        }
+        sdsfree(protocol); //free protocol
+    }
+    return C_OK;
+}
+
+/* Record the rdb-channel main client id negotiated via +RDBCHANNELSYNC into the server. */
+void gtidReplicationSetRdbChannelMainClientId(uint64_t client_id) {
+    server.repl_main_ch_client_id = client_id;
+}
+
 /* test */
 void gtidInitTestEnv() {
     server.repl_buffer_blocks = listCreate();

--- a/xredis/xredis_gtid_repl.c
+++ b/xredis/xredis_gtid_repl.c
@@ -32,58 +32,22 @@
 #include "xredis_gtid_adaptation_version.h"
 
 
-int replicationSetupSlaveForXFullResync(client *slave, long long offset) {
-    int ret = C_OK;
-    sds gtid_lost_repr = NULL, repr = NULL;
+sds buildXfullProtocol() {
+    sds gtid_lost_repr = NULL;
     size_t master_uuid_len = 0;
     const char *master_uuid = getMasterUuid(&master_uuid_len);
-
-    repr = sdsnew("+XFULLRESYNC");
-
     gtid_lost_repr = gtidSetQuoteIfEmpty(gtidSetDump(server.gtid_lost));
-    repr = sdscat(repr," GTID.LOST ");
-    repr = sdscatlen(repr,gtid_lost_repr,sdslen(gtid_lost_repr));
-
-    repr = sdscat(repr," MASTER.UUID ");
-    repr = sdscatlen(repr,master_uuid,master_uuid_len);
-
-    repr = sdscat(repr," REPLID ");
-    repr = sdscat(repr,server.replid);
-
-    repr = sdscat(repr," REPLOFF ");
-    sds reploff = sdsfromlonglong(ctrip_getMasterReploff());
-    repr = sdscatsds(repr,reploff);
-    sdsfree(reploff);
-
-    repr = sdscat(repr, "\r\n");
-
-    slave->psync_initial_offset = offset;
-    slave->replstate = SLAVE_STATE_WAIT_BGSAVE_END;
-    /* We are going to accumulate the incremental changes for this
-     * slave as well. Set slaveseldb to -1 in order to force to re-emit
-     * a SELECT statement in the replication stream. */
-    server.slaveseldb = -1;
-
-    /* Don't send this reply to slaves that approached us with
-     * the old SYNC command. */
-    if (!(slave->flags & CLIENT_PRE_PSYNC)) {
-        if (connWrite(slave->conn,repr,sdslen(repr)) != (int)sdslen(repr)) {
-            freeClientAsync(slave);
-            ret = C_ERR;
-            goto end;
-        }
-    }
-
-end:
-    sdsfree(gtid_lost_repr), sdsfree(repr);
-    return ret;
+    sds result = sdscatprintf(sdsempty(), "+XFULLRESYNC GTID.LOST %s MASTER.UUID %s REPLID %s REPLOFF %lld\r\n",
+                          gtid_lost_repr, master_uuid,server.replid,ctrip_getMasterReploff());
+    sdsfree(gtid_lost_repr);
+    return result;
 }
 
 int ctrip_replicationSetupSlaveForFullResync(client *slave, long long offset) {
     if (server.repl_mode->mode != REPL_MODE_XSYNC)
         return replicationSetupSlaveForFullResync(slave, offset);
     else
-        return replicationSetupSlaveForXFullResync(slave, offset);
+        return replicationSetupSlaveForXFullResync(slave, offset, buildXfullProtocol);
 }
 
 #define GTID_XSYNC_MAX_REPLY_SIZE (64*1024)
@@ -1239,7 +1203,11 @@ int ctrip_slaveTryPartialResynchronizationRead(connection *conn, sds reply) {
     }
 
     if (parsed->type == SYNC_REPLY_RDBCHANNELSYNC) {
-        goto by_redis;
+        gtidReplicationSetRdbChannelMainClientId(parsed->rdbchannelsync.client_id);
+        serverLog(LL_NOTICE, "[%s] PSYNC is not possible, initialize RDB channel.",
+                replModeName(server.repl_mode->mode));
+        result = PSYNC_FULLRESYNC_RDBCHANNEL;
+        goto end;
     }
 
     if (server.repl_mode->mode != REPL_MODE_XSYNC) {


### PR DESCRIPTION
When in XSYNC (GTID) mode, the full-resync setup function replicationSetupSlaveForXFullResync was missing the rdb-channel path transition. The main channel client stayed in WAIT_RDB_CHANNEL state forever, never reaching SEND_BULK_AND_STREAM, which prevented the replica from being put online after fullsync completed.

Add the same rdb-channel logic already present in the non-GTID replicationSetupSlaveForFullResync: look up the main channel by main_ch_client_id and transition its state to
SLAVE_STATE_SEND_BULK_AND_STREAM when the rdb channel is set up.