### PR TITLE
Fix blmpop/bzmpop test args to valid command syntax

### DIFF
--- a/xredis/tests/gtid/gtid.tcl
+++ b/xredis/tests/gtid/gtid.tcl
@@ -604,10 +604,10 @@ start_server {tags {"gtid"} overrides {gtid-enabled yes}} {
                 "brpoplpush"    { set args [list $cmd src_key dst_key 1] }
                 "blpop"         { set args [list $cmd list_key 1] }
                 "brpop"         { set args [list $cmd list_key 1] }
-                "blmpop"        { set args [list $cmd list_key 2 LEFT 1] }
+                "blmpop"        { set args [list $cmd 0 1 list_key LEFT] }
                 "bzpopmin"      { set args [list $cmd zset_key 1] }
                 "bzpopmax"      { set args [list $cmd zset_key 1] }
-                "bzmpop"        { set args [list $cmd hash_key 2 MIN 1] }
+                "bzmpop"        { set args [list $cmd 0 1 hash_key MIN] }
                 "zmpop"         { set args [list $cmd hash_key 2 MIN] }
                 "spop"          { set args [list $cmd spop_key] }
                 default         { fail "unexpected command $cmd" }


### PR DESCRIPTION
blmpop and bzmpop were invoked with malformed argv in the 'GTID should reject commands that rewrite argv' test (missing the timeout slot and shifting key/numkeys). The full command list is a regression guard that expects these commands to be rejected via the GTID_NON_DETERMINISM flag, so each command must first be supplied with syntactically valid arguments.

- blmpop: list_key 2 LEFT 1  ->  0 1 list_key LEFT  (BLMPOP timeout numkeys key LEFT)
- bzmpop: hash_key 2 MIN 1  ->  0 1 hash_key MIN   (BZMPOP timeout numkeys key MIN)