### PR TITLE
[hotfix] move GTIDX GAPLOG LEN/ALL to INFO GTID gtid_gaplog[_entries]

### DIFF
--- a/xredis/tests/gtid/gaplog.tcl
+++ b/xredis/tests/gtid/gaplog.tcl
@@ -250,11 +250,11 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
 
         $client CONFIG SET gtid-xsync-max-gap 10000
 
-        set len [$client GTIDX GAPLOG LEN]
+        set len [gaploglen $client]
         assert_equal $len 0
 
         $client GTIDX GAPLOG CLEAR
-        set len [$client GTIDX GAPLOG LEN]
+        set len [gaploglen $client]
         assert_equal $len 0
     }
 }
@@ -570,7 +570,7 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
                 after 200
 
 
-                set b_gaplog_len [$B GTIDX GAPLOG LEN]
+                set b_gaplog_len [gaploglen $B]
                 puts "DEBUG: B gaplog length after reconnect: $b_gaplog_len"
                 assert {$b_gaplog_len >= 2}
 
@@ -597,7 +597,7 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
                 after 200
 
 
-                set c_gaplog_len [$C GTIDX GAPLOG LEN]
+                set c_gaplog_len [gaploglen $C]
                 puts "DEBUG: C gaplog length after skip-level switch: $c_gaplog_len"
 
 
@@ -656,7 +656,7 @@ proc run_extreme_test {maxgap backlog data_multiplier} {
                 wait_for_sync $S
                 after 1000
 
-                set gaplog_len [$S GTIDX GAPLOG LEN]
+                set gaplog_len [gaploglen $S]
                 puts "DEBUG: Gaplog length after reconnect: $gaplog_len"
 
                 assert {$gaplog_len > 0}
@@ -685,7 +685,7 @@ proc run_extreme_test {maxgap backlog data_multiplier} {
                     after 20
                 }
 
-                set gaplog_len [$S GTIDX GAPLOG LEN]
+                set gaplog_len [gaploglen $S]
                 puts "DEBUG: Gaplog length after $total_rapid_switches rapid switches: $gaplog_len"
 
                 assert {$gaplog_len > 0}

--- a/xredis/tests/gtid/gaplog_commands.tcl
+++ b/xredis/tests/gtid/gaplog_commands.tcl
@@ -2,27 +2,25 @@
 
 
 start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled yes}} {
-    test "GAPLOG-CMD-001: GAPLOG LEN - empty gaplog returns 0" {
-        set len [r GTIDX GAPLOG LEN]
-        assert {$len == 0}
+    test "GAPLOG-CMD-001: INFO GTID - gtid_gaplog_entries is 0 when gaplog empty" {
+        assert_equal [get_gaplog_entries r] 0
+        set info [r INFO gtid]
+        assert_match "*gtid_gaplog_entries:0*" $info
+        # Empty gtidSet renders as a bare empty value in INFO (no quote wrapping);
+        # do NOT match with "*gtid_gaplog:\"\"*".
+        assert_equal [get_gaplog_gtidset r] ""
     }
 
-    test "GAPLOG-CMD-002: GAPLOG CLEAR - clears all entries" {
-        set result [r GTIDX GAPLOG CLEAR]
-        assert_equal $result "OK"
-
-        set len [r GTIDX GAPLOG LEN]
-        assert {$len == 0}
+    test "GAPLOG-CMD-002: GAPLOG CLEAR - INFO GTID gtid_gaplog_entries becomes 0" {
+        assert_equal [r GTIDX GAPLOG CLEAR] "OK"
+        assert_equal [get_gaplog_entries r] 0
+        set info [r INFO gtid]
+        assert_match "*gtid_gaplog_entries:0*" $info
     }
 }
 
 
 start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled yes}} {
-    test "GAPLOG-CMD-009: GAPLOG LEN - wrong args count error" {
-        catch {r GTIDX GAPLOG LEN "extra-arg"} err
-        assert_match "*wrong*" $err
-    }
-
     test "GAPLOG-CMD-012: GAPLOG invalid subcommand error" {
         catch {r GTIDX GAPLOG INVALID} err
         assert_match "*subcommand*" $err
@@ -30,20 +28,31 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
 }
 
 start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled yes}} {
-    test "GAPLOG-CMD-013: GTIDX HELP contains GAPLOG commands" {
+    test "GAPLOG-CMD-013: GTIDX HELP contains remaining GAPLOG commands" {
         set help [r GTIDX HELP]
-        assert_match "*GAPLOG LEN*" $help
         assert_match "*GAPLOG LIST*" $help
-        assert_match "*GAPLOG ALL*" $help
         assert_match "*GAPLOG CLEAR*" $help
+        assert_no_match "*GAPLOG LEN*" $help
+        assert_no_match "*GAPLOG ALL*" $help
     }
 }
-
 start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled yes}} {
-    test "GAPLOG-CMD-014: INFO GTID contains gaplog stats" {
+    test "GAPLOG-CMD-014: INFO GTID contains gaplog stats fields" {
         r GTIDX GAPLOG CLEAR
         set info [r INFO gtid]
         assert_match "*gtid_gaplog_entries:0*" $info
+        # Empty gtidSet renders as a bare empty value in INFO (no quote wrapping);
+        # do NOT match with "*gtid_gaplog:\"\"*".
+        assert_equal [get_gaplog_gtidset r] ""
+    }
+
+    test "GAPLOG-CMD-015: INFO GTID gtid_gaplog_entries reflects CLEAR effect" {
+        r GTIDX GAPLOG CLEAR
+        set info [r INFO gtid]
+        assert_match "*gtid_gaplog_entries:0*" $info
+        # Empty gtidSet renders as a bare empty value in INFO (no quote wrapping);
+        # do NOT match with "*gtid_gaplog:\"\"*".
+        assert_equal [get_gaplog_gtidset r] ""
     }
 }
 
@@ -142,7 +151,7 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
             }
             assert {$uuid != ""}
 
-            set page_count [$S GTIDX GAPLOG LEN]
+            set page_count [gaploglen $S]
             assert {$page_count > 0}
 
             set list_result [$S GTIDX GAPLOG LIST 0 $page_count]
@@ -193,13 +202,13 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
         }
 
         test "GAPLOG-LIST-007: LIST start_idx out of range returns empty array" {
-            set gaplog_len [$S GTIDX GAPLOG LEN]
+            set gaplog_len [gaploglen $S]
             set result [$S GTIDX GAPLOG LIST $gaplog_len 10]
             assert_equal $result {}
         }
 
         test "GAPLOG-LIST-008: LIST count exceeds remaining entries - truncated" {
-            set gaplog_len [$S GTIDX GAPLOG LEN]
+            set gaplog_len [gaploglen $S]
             set start_idx [expr {$gaplog_len - 2}]
             if {$start_idx < 0} { set start_idx 0 }
             set result [$S GTIDX GAPLOG LIST $start_idx 100]
@@ -213,25 +222,24 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
     start_server {overrides {gtid-enabled yes gtid-gaplog-enabled yes gtid-xsync-max-gap 10000}} {
         set M [srv -1 client]; set Mh [srv -1 host]; set Mp [srv -1 port]; set S [srv 0 client]
 
-        test "GAPLOG-ALL-001: ALL returns empty gtidSet when gaplog empty" {
+        test "GAPLOG-ALL-001: INFO GTID gtid_gaplog is empty when gaplog empty" {
             $S GTIDX GAPLOG CLEAR
-            set result [$S GTIDX GAPLOG ALL]
-            assert_equal $result "" {}
+            assert_equal [get_gaplog_gtidset $S] ""
         }
 
-        test "GAPLOG-ALL-002: ALL returns correct gtidSet encoding" {
+        test "GAPLOG-ALL-002: INFO GTID gtid_gaplog encodes gaplog gnos correctly" {
             $S replicaof $Mh $Mp; wait_for_sync $S
             $M set m_b m_v; wait_for_ofs_sync $S $M
             $S replicaof no one; after 100
             $S set k1 v1; $S set k2 v2; $S set k3 v3
             set su [get_slave_gtid_uuid $S]
             replicaof_xcontinue $S $Mh $Mp
-            set all [$S GTIDX GAPLOG ALL]
+            set all [get_gaplog_gtidset $S]
             assert {[string length $all] > 0}
             assert_match "${su}:*" $all
         }
 
-        test "GAPLOG-ALL-003: ALL gno range covers written gnos" {
+        test "GAPLOG-ALL-003: INFO GTID gtid_gaplog gno range covers written gnos" {
             $S replicaof $Mh $Mp; wait_for_sync $S
             $M set m_b2 m_v; wait_for_ofs_sync $S $M
             $S replicaof no one; after 100
@@ -240,7 +248,7 @@ start_server {tags {"gaplog"} overrides {gtid-enabled yes gtid-gaplog-enabled ye
             set su [get_slave_gtid_uuid $S]
             replicaof_xcontinue $S $Mh $Mp
             set gl [gaploglen $S]
-            set all [$S GTIDX GAPLOG ALL]
+            set all [get_gaplog_gtidset $S]
             set pattern "${su}:"
             set idx [string first $pattern $all]
             assert {$idx >= 0}

--- a/xredis/tests/support/gtid.tcl
+++ b/xredis/tests/support/gtid.tcl
@@ -93,31 +93,6 @@ proc get_gaplog_entries {client} {
 }
 
 proc get_slave_gtid_uuid {client} {
-    set seq [$client GTIDX seq gtid.set]
-    set parts [split $seq ","]
-    if {[llength $parts] >= 2} {
-        set uuid_gno [lindex $parts 1]
-        set uuid [lindex [split $uuid_gno ":"] 0]
-        return $uuid
-    } elseif {[llength $parts] == 1} {
-        set uuid_gno [lindex $parts 0]
-        set uuid [lindex [split $uuid_gno ":"] 0]
-        return $uuid
-    }
-    return ""
-}
-
-
-
-proc get_info_property {r section line property} {
-    set str [$r info $section]
-    if {[regexp ".*${line}:\[^\r\n\]*${property}=(\[^,\r\n\]*).*" $str match submatch]} {
-        return $submatch
-    }
-    return ""
-}
-
-proc get_slave_gtid_uuid {client} {
     set info [$client INFO gtid]
     foreach line [split $info "\r\n"] {
         if {[string match "gtid_uuid:*" $line]} {
@@ -127,17 +102,17 @@ proc get_slave_gtid_uuid {client} {
     return ""
 }
 
-
-proc get_gaplog_entries {client} {
-    set len [$client GTIDX GAPLOG LEN]
-    return $len
+proc get_info_property {r section line property} {
+    set str [$r info $section]
+    if {[regexp ".*${line}:\[^\r\n\]*${property}=(\[^,\r\n\]*).*" $str match submatch]} {
+        return $submatch
+    }
+    return ""
 }
-
 
 proc get_uuid {client} {
     return [get_slave_gtid_uuid $client]
 }
-
 proc get_xsync_continue_stat {S} { return [get_info_property $S gtid gtid_sync_stat xsync_xcontinue] }
 proc wait_xsync_continue_stat {S o} {
     wait_for_condition 50 100 { [get_xsync_continue_stat $S] > $o } else {
@@ -149,10 +124,26 @@ proc replicaof_xcontinue {S Mh Mp} {
     set o [get_xsync_continue_stat $S]; $S replicaof $Mh $Mp; wait_for_sync $S
     wait_xsync_continue_stat $S $o; after 200
 }
-
-proc gaploglen {c} { return [$c GTIDX GAPLOG LEN] }
+proc gaploglen {c} {
+    return [get_gaplog_entries $c]
+}
+proc get_gaplog_gtidset {client} {
+    set info [$client INFO gtid]
+    foreach line [split $info "\r\n"] {
+        if {[string match "gtid_gaplog:*" $line]} {
+            set raw [string range $line 12 end]
+            if {[string length $raw] >= 2 \
+                    && [string index $raw 0] eq "\"" \
+                    && [string index $raw end] eq "\""} {
+                return [string range $raw 1 end-1]
+            }
+            return $raw
+        }
+    }
+    return ""
+}
 proc gaplog_get_key_type {client key} {
-    set gaplog_len [$client GTIDX GAPLOG LEN]
+    set gaplog_len [gaploglen $client]
     if {$gaplog_len == 0} { return "" }
     set list_result [$client GTIDX GAPLOG LIST 0 $gaplog_len]
     foreach entry $list_result {
@@ -172,7 +163,7 @@ proc gaplog_get_key_type {client key} {
     return ""
 }
 proc gaplog_get_key_type_debug {client key} {
-    set gaplog_len [$client GTIDX GAPLOG LEN]
+    set gaplog_len [gaploglen $client]
     if {$gaplog_len == 0} { puts "gaplog empty"; return "" }
     set list_result [$client GTIDX GAPLOG LIST 0 $gaplog_len]
     puts "gaplog entries: $gaplog_len"

--- a/xredis/xredis_gtid.c
+++ b/xredis/xredis_gtid.c
@@ -354,6 +354,7 @@ sds genGtidInfoString(sds info) {
 
     sds gtid_executed_repr = gtidSetDump(server.gtid_executed);
     sds gtid_lost_repr = gtidSetDump(server.gtid_lost);
+    sds gtid_gaplog_repr = gtidSetDump(gtidGaplogGetAll(server.gtid_gap_log));
 
     const char *master_uuid = getMasterUuid(NULL);
     info  = sdscatprintf(info,
@@ -377,7 +378,9 @@ sds genGtidInfoString(sds info) {
             "gtid_uuid_interested:%s\r\n"
             "gtid_xsync_fullresync_indicator:%lld\r\n"
             "gtid_executed_cmd_count:%lld\r\n"
-            "gtid_ignored_cmd_count:%lld\r\n",
+            "gtid_ignored_cmd_count:%lld\r\n"
+            "gtid_gaplog:%s\r\n"
+            "gtid_gaplog_entries:%ld\r\n",
             server.uuid,
             master_uuid,
             gtid_set_repr,
@@ -398,12 +401,15 @@ sds genGtidInfoString(sds info) {
             server.gtid_uuid_interested,
             server.gtid_xsync_fullresync_indicator,
             server.gtid_executed_cmd_count,
-            server.gtid_ignored_cmd_count);
+            server.gtid_ignored_cmd_count,
+            gtid_gaplog_repr,
+            gtidGaplogSize(server.gtid_gap_log)
+        );
 
     sdsfree(gtid_set_repr);
     sdsfree(gtid_executed_repr);
     sdsfree(gtid_lost_repr);
-
+    sdsfree(gtid_gaplog_repr);
     info = sdscatprintf(info,"gtid_sync_stat:");
     for (int i = 0; i < GTID_SYNC_TYPES; i++) {
         long long count = server.gtid_sync_stat[i];
@@ -414,12 +420,6 @@ sds genGtidInfoString(sds info) {
         }
     }
     info = sdscatprintf(info,"\r\n");
-
-    if (server.gtid_gap_log != NULL) {
-        info = sdscatprintf(info,
-                "gtid_gaplog_entries:%ld\r\n",
-                gtidGaplogSize(server.gtid_gap_log));
-    }
 
     return info;
 }
@@ -465,14 +465,10 @@ void gtidxCommand(client *c) {
             "    Locate xsync continue position",
             "UUID-INTRESTED SET <*|?>",
             "    SET uuid.interested to * or ?",
-            "GAPLOG LEN",
-            "    Get gaplog entries count.",
             "GAPLOG LIST <start_index> <count>",
             "    List gaplog entries by index.",
             "GAPLOG CLEAR",
             "    Clear all gaplog entries.",
-            "GAPLOG ALL",
-            "    Get gtidSet of all gnos stored in gaplog.",
             NULL
         };
         addReplyHelp(c, help);
@@ -643,9 +639,7 @@ void gtidxCommand(client *c) {
             addReplyError(c,"Syntax error");
         }
     } else if (!strcasecmp(c->argv[1]->ptr,"gaplog") && c->argc >= 3) {
-        if (!strcasecmp(c->argv[2]->ptr,"len") && c->argc == 3)  {
-            addReplyLongLong(c, gtidGaplogSize(server.gtid_gap_log));
-        } else if (!strcasecmp(c->argv[2]->ptr,"list") && c->argc == 5) {
+        if (!strcasecmp(c->argv[2]->ptr,"list") && c->argc == 5) {
             long long start_idx, count;
             if (getLongLongFromObjectOrReply(c, c->argv[3], &start_idx, NULL) != C_OK) return;
             if (getLongLongFromObjectOrReply(c, c->argv[4], &count, NULL) != C_OK) return;
@@ -680,13 +674,6 @@ void gtidxCommand(client *c) {
             gtidGaplogRelease(server.gtid_gap_log);
             server.gtid_gap_log = gtidGaplogNew(server.gtid_xsync_max_gap);
             addReply(c,shared.ok);
-        } else if (!strcasecmp(c->argv[2]->ptr,"all") && c->argc == 3) {
-            gtidSet *gtid_set = gtidGaplogGetAll(server.gtid_gap_log);
-            size_t maxlen = gtidSetEstimatedEncodeBufferSize(gtid_set);
-            char *buf = zmalloc(maxlen);
-            size_t len = gtidSetEncode(buf, maxlen, gtid_set);
-            addReplyBulkCBuffer(c, buf, len);
-            zfree(buf);
         } else {
             addReplySubcommandSyntaxError(c);
         }


### PR DESCRIPTION
The two sub-commands returned redundant data already exposed by INFO GTID. Consolidate them into two INFO fields:

- gtid_gaplog_entries: ring buffer entry count (was GAPLOG LEN)
- gtid_gaplog: encoded gtidSet of all gnos stored in the ring (was GAPLOG ALL)

Test migration:
- support/gtid.tcl: drop duplicate get_gaplog_entries/get_slave_gtid_uuid definitions, add get_gaplog_gtidset helper, redirect gaploglen to INFO.
- tests/gtid/gaplog_commands.tcl: GAPLOG-CMD-001/002/014/015 now read INFO GTID instead of removed commands; GAPLOG-CMD-009 dropped (no longer applicable); GAPLOG-CMD-013 asserts HELP no longer mentions LEN/ALL; GAPLOG-ALL-001/002/003 redirected to get_gaplog_gtidset.
- tests/gtid/gaplog.tcl: six GTIDX GAPLOG LEN call sites migrated to gaploglen helper.